### PR TITLE
bump gnome runtime to v46

### DIFF
--- a/org.gabmus.gfeeds.json
+++ b/org.gabmus.gfeeds.json
@@ -2,7 +2,7 @@
     "app-id": "org.gabmus.gfeeds",
     "command": "gfeeds",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--device=dri",

--- a/org.gabmus.gfeeds.json
+++ b/org.gabmus.gfeeds.json
@@ -12,9 +12,7 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--talk-name=org.freedesktop.Flatpak",
-        "--filesystem=xdg-data/fonts",
         "--persist=xdg-data/fonts",
-        "--filesystem=xdg-config/fontconfig",
         "--persist=xdg-config/fontconfig"
     ],
     "cleanup": [


### PR DESCRIPTION
The GNOME 44 runtime is no longer supported as of March 20, 2024.
Closes https://github.com/flathub/org.gabmus.gfeeds/issues/15